### PR TITLE
Request Tracking Permissions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,23 +1,38 @@
-import { StatusBar } from 'expo-status-bar';
 import Constants from 'expo-constants';
-import * as React from 'react';
+import { StatusBar } from 'expo-status-bar';
+import { getTrackingPermissionsAsync, requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import { WebView } from 'react-native-webview';
+import TrackingPermissionsDeclined from './client/components/TrackingPermissionsDeclined';
 
 export default function App() {
-  return (
-    <>
-      <StatusBar
-        hidden={false}
-        style="dark"
-      />
-      <WebView 
-        sharedCookiesEnabled={true}
-        source={{ uri: 'https://stream.resonate.coop/discover' }}
-        style={styles.container}
-        />
-    </>
-  );
+  const [trackingPermissions, setTrackingPermissions] = useState(false);
+  useEffect(() => {
+    (async () => {
+      const { granted } = await getTrackingPermissionsAsync();
+      if (granted) {
+        setTrackingPermissions(true);
+      } else {
+        const { status } = await requestTrackingPermissionsAsync();
+        setTrackingPermissions(status === 'granted');
+      }
+    })();
+  }, []);
+
+  const mainView = <>
+    <StatusBar
+      hidden={false}
+      style="dark"
+    />
+    <WebView
+      sharedCookiesEnabled={true}
+      source={{ uri: 'https://stream.resonate.coop/discover' }}
+      style={styles.container}
+    />
+  </>
+
+  return trackingPermissions ? mainView : <TrackingPermissionsDeclined />;
 }
 
 const styles = StyleSheet.create({

--- a/app.json
+++ b/app.json
@@ -30,6 +30,14 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      [
+        "expo-tracking-transparency",
+        {
+          "userTrackingPermission": "To ensure you get the best experience, Resonate uses cookies. Functional cookies are used to keep you logged in for a while and remember your theme settings. Disallowing tracking permissions precludes use of this app. Visit https://resonate.is/cookie-policy to learn more."
+        }
+      ]
+    ]
   }
 }

--- a/client/components/TrackingPermissionsDeclined.tsx
+++ b/client/components/TrackingPermissionsDeclined.tsx
@@ -1,0 +1,48 @@
+import Constants from 'expo-constants';
+import React from 'react';
+import { Image, Linking, StyleSheet, Text, View } from 'react-native';
+
+export default function TrackingPermissionsDeclined() {
+  return (<View style={styles.container}>
+    <Image
+      style={styles.image}
+      source={require('../../assets/icon.png')}
+    />
+    <Text
+      style={styles.text}>
+      {"\n"}
+      To ensure you get the best experience, Resonate uses cookies. Functional cookies are used to keep you logged in for a while and remember your theme settings. Disallowing tracking permissions precludes use of this app. To learn more, please visit:{"\n"}
+    </Text>
+    <Text
+      style={{ ...styles.link, ...styles.text }}
+      onPress={() => Linking.openURL('https://resonate.is/cookie-policy')}>
+      Resonate's Cookie Policy
+    </Text>
+    <Text
+      style={styles.text}>
+      {"\n"}
+      In the event that you declined tracking permissions, please close and re-open, and, failing that, reinstall the app to be prompted again. Thank you.
+    </Text>
+  </View>)
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginTop: Constants.statusBarHeight,
+  },
+  link: {
+    color: 'blue',
+  },
+  image: {
+    height: 360,
+    marginLeft: '25%',
+    marginRight: '25%',
+    width: '50%',
+  },
+  text: {
+    fontSize: 24,
+    marginLeft: Constants.statusBarHeight * 1.5,
+    marginRight: Constants.statusBarHeight * 1.5,
+  }
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "expo": "~44.0.0",
     "expo-status-bar": "~1.2.0",
     "expo-system-ui": "~1.1.0",
+    "expo-tracking-transparency": "~2.1.0",
     "expo-web-browser": "~10.1.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2498,6 +2498,13 @@ expo-system-ui@~1.1.0:
     "@react-native/normalize-color" "^2.0.0"
     debug "^4.3.2"
 
+expo-tracking-transparency@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/expo-tracking-transparency/-/expo-tracking-transparency-2.1.0.tgz#74f44d660f0d0679fec556b3c76a22a930116e74"
+  integrity sha512-I63RxvM/gv/+1YlWaSA0wbBIZayPZ/fw2Ptg2NfPgFNYoEPBvCe+r7Ni3giODGsl3YEdPQyF1gJDr0/PO1QHsg==
+  dependencies:
+    "@expo/config-plugins" "^4.0.2"
+
 expo-web-browser@~10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/expo-web-browser/-/expo-web-browser-10.1.0.tgz#fd91695c44e0f3006da3089f230573c1cb3b026a"


### PR DESCRIPTION
Per https://community.resonate.is/t/minimal-stream-phone-app/2613/9, Apple requires users to allow tracking permissions. These changes only load the app if the user allows, and if they disallow they are informed that they need to allow these permissions in order to be able to use the app:

![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-02-18 at 11 09 48](https://user-images.githubusercontent.com/60944077/154767880-57037a22-6c8f-4c16-851b-aede1ec56f1e.png)