### PR TITLE
Dark Status Bar color matches UI

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,10 @@ import React, {
   useEffect,
   useState,
 } from 'react';
-import { StyleSheet } from 'react-native';
+import {
+  StyleSheet,
+  useColorScheme,
+} from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
 import CookiePolicy from './client/components/CookiePolicy';
@@ -14,6 +17,8 @@ import CustomStatusBar from './client/components/CustomStatusBar';
 
 export default function App() {
   const [trackingPermissions, setTrackingPermissions] = useState(false);
+  const colorScheme = useColorScheme();
+  const isDark: boolean = colorScheme === 'dark';
 
   useEffect(() => {
     (async () => {
@@ -30,14 +35,14 @@ export default function App() {
   const content = trackingPermissions
     ? <WebView
       sharedCookiesEnabled={true}
-      source={{ uri: 'https://stream.resonate.coop/discover' }}
+      source={{ uri: 'https://stream.resonate.ninja/discover' }}
       style={styles.container}
     />
     : <CookiePolicy />;
 
   return (
     <SafeAreaProvider>
-      <CustomStatusBar />
+      <CustomStatusBar trackingPermissions={trackingPermissions} />
       {content}
     </SafeAreaProvider>
   )

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Commit messages should be written in present tense describing what the committed
 
 - [Expo](https://expo.dev/)
 - [React Native](https://reactnative.dev/)
-- [TypeScript](typescriptlang.org/')
+- [TypeScript](https://typescriptlang.org/')
+
 
 ## 📑 License
 
@@ -106,6 +107,7 @@ Commit messages should be written in present tense describing what the committed
 [GNU General Public License v3.0](https://github.com/peterklingelhofer/stream-app/blob/master/LICENSE)
 
 Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights.
+
 
 ## 📇 Contact
 

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "stream-app",
     "slug": "stream-app",
     "privacy": "unlisted",
-    "version": "1.0.3",
+    "version": "1.0.5",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -21,14 +21,15 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.resonate.stream-app",
-      "buildNumber": "1.0.3"
+      "buildNumber": "1.0.5"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#FFFFFF"
       },
-      "package": "com.resonate.streamapp"
+      "package": "com.resonate.streamapp",
+      "versionCode": 3
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/client/components/CookiePolicy.tsx
+++ b/client/components/CookiePolicy.tsx
@@ -1,6 +1,13 @@
 import Constants from 'expo-constants';
 import React from 'react';
-import { Image, Linking, Platform, ScrollView, StyleSheet, Text } from 'react-native';
+import {
+  Image,
+  Linking,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+} from 'react-native';
 
 export default function CookiePolicy() {
   return (
@@ -21,12 +28,7 @@ export default function CookiePolicy() {
           </Text>
           <Text
             style={styles.text}>
-            and enable
-          </Text>
-          <Text
-            style={{ ...styles.boldText, ...styles.text }}>
-            Allow Apps to Request to Track
-            {"\n"}
+            and enable permissions for Resonate.
           </Text>
         </>
       )}

--- a/client/components/CustomStatusBar.tsx
+++ b/client/components/CustomStatusBar.tsx
@@ -1,22 +1,25 @@
 import {
+    StatusBar,
     useColorScheme,
     View,
-    StatusBar,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+type Props = {
+    trackingPermissions: boolean;
+}
 
-export default function CustomStatusBar() {
-    const colorScheme = useColorScheme();
+export default function CustomStatusBar({ trackingPermissions }: Props) {
     const insets = useSafeAreaInsets();
-    const isDark = colorScheme === 'dark';
+    const colorScheme = useColorScheme();
+    const isDark: boolean = colorScheme === 'dark' && trackingPermissions;
 
     return (
-        <View style={{ height: insets.top, backgroundColor: isDark ? '#000' : '#fff' }}>
+        <View style={{ height: insets.top, backgroundColor: isDark ? '#181A1B' : '#fff' }}>
             {isDark
                 ? <StatusBar
                     animated={true}
-                    backgroundColor={'#000'}
+                    backgroundColor={'#181A1B'}
                     barStyle={'light-content'}
                 />
                 : <StatusBar

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 0.47.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}


### PR DESCRIPTION
Status bar color now matches dark but not completely black color of the Resonate dark mode UI.
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-02-21 at 21 33 37](https://user-images.githubusercontent.com/60944077/155058626-8b669048-8bf4-4316-b19c-76ccb26ad637.png)

Revised Cookie Policy language for iOS to better reflect how users can allow permissions:
![IMAGE 2022-02-21 21:37:14](https://user-images.githubusercontent.com/60944077/155058639-e330c65f-f1fc-4fcf-9010-88a17b53cfe2.jpg)

Status Bar on Cookie Policy page is always light, regardless of system preference, as this component (currently) has an all white background.