### PR TITLE
WebView URI default stream path

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -35,7 +35,7 @@ export default function App() {
   const content = trackingPermissions
     ? <WebView
       sharedCookiesEnabled={true}
-      source={{ uri: 'https://stream.resonate.ninja/discover' }}
+      source={{ uri: 'https://stream.resonate.coop/discover' }}
       style={styles.container}
     />
     : <CookiePolicy />;

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "stream-app",
     "slug": "stream-app",
     "privacy": "unlisted",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -21,7 +21,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.resonate.stream-app",
-      "buildNumber": "1.0.5"
+      "buildNumber": "1.0.6"
     },
     "android": {
       "adaptiveIcon": {
@@ -29,7 +29,7 @@
         "backgroundColor": "#FFFFFF"
       },
       "package": "com.resonate.streamapp",
-      "versionCode": 3
+      "versionCode": 4
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/client/components/CustomStatusBar.tsx
+++ b/client/components/CustomStatusBar.tsx
@@ -13,18 +13,19 @@ export default function CustomStatusBar({ trackingPermissions }: Props) {
     const insets = useSafeAreaInsets();
     const colorScheme = useColorScheme();
     const isDark: boolean = colorScheme === 'dark' && trackingPermissions;
+    const backgroundColor = isDark ? '#181A1B' : '#fff';
 
     return (
-        <View style={{ height: insets.top, backgroundColor: isDark ? '#181A1B' : '#fff' }}>
+        <View style={{ height: insets.top, backgroundColor }}>
             {isDark
                 ? <StatusBar
                     animated={true}
-                    backgroundColor={'#181A1B'}
+                    backgroundColor={backgroundColor}
                     barStyle={'light-content'}
                 />
                 : <StatusBar
                     animated={true}
-                    backgroundColor={'#fff'}
+                    backgroundColor={backgroundColor}
                     barStyle={'dark-content'}
                 />}
         </View>


### PR DESCRIPTION
Was mentioned that listener playback can be better tested on the default website path, so we're going back to that for now.