### PR TITLE
Disallowing tracking permitted, swipe navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,44 +6,68 @@ import React, {
   useEffect,
   useState,
 } from 'react';
-import {
-  StyleSheet,
-  useColorScheme,
-} from 'react-native';
+import { StyleSheet } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
 import CookiePolicy from './client/components/CookiePolicy';
 import CustomStatusBar from './client/components/CustomStatusBar';
+import {
+  cookiePreferences,
+  getPermissionsGranted,
+  storePermissionsGranted,
+} from './client/helpers/Permissions';
 
 export default function App() {
   const [trackingPermissions, setTrackingPermissions] = useState(false);
-  const colorScheme = useColorScheme();
-  const isDark: boolean = colorScheme === 'dark';
+  const [isRequestingPermissions, setIsRequestingPermissions] = useState(true);
+  const [didPermissionsChange, setDidPermissionsChange] = useState(false);
 
   useEffect(() => {
     (async () => {
+      const arePermissionsGrantedHistorically = await getPermissionsGranted();
       const { granted } = await getTrackingPermissionsAsync();
       if (granted) {
         setTrackingPermissions(true);
+        if (!arePermissionsGrantedHistorically) {
+          storePermissionsGranted(true);
+          setDidPermissionsChange(true);
+        }
       } else {
         const { status } = await requestTrackingPermissionsAsync();
-        setTrackingPermissions(status === 'granted');
+        const arePermissionsGranted = status === 'granted';
+        setTrackingPermissions(arePermissionsGranted);
+        if (arePermissionsGranted !== arePermissionsGrantedHistorically) {
+          storePermissionsGranted(arePermissionsGranted);
+          setDidPermissionsChange(true);
+        }
       }
+
+      setIsRequestingPermissions(false);
     })();
   }, []);
 
-  const content = trackingPermissions
-    ? <WebView
-      sharedCookiesEnabled={true}
-      source={{ uri: 'https://stream.resonate.coop/discover' }}
-      style={styles.container}
-    />
-    : <CookiePolicy />;
-
   return (
     <SafeAreaProvider>
-      <CustomStatusBar trackingPermissions={trackingPermissions} />
-      {content}
+      <CustomStatusBar isRequestingPermissions={isRequestingPermissions} />
+      {
+        isRequestingPermissions
+          ? <CookiePolicy />
+          : <WebView
+            allowsBackForwardNavigationGestures
+            cacheEnabled={didPermissionsChange}
+            injectedJavaScript={cookiePreferences(trackingPermissions)}
+            pullToRefreshEnabled
+            sharedCookiesEnabled={trackingPermissions}
+            source={{
+              uri: 'https://stream.resonate.coop/discover',
+              headers: {
+                'doNotTrack': trackingPermissions ? '0' : '1',
+              },
+            }}
+            style={styles.container}
+            textInteractionEnabled={false}
+          />
+      }
     </SafeAreaProvider>
   )
 }

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "stream-app",
     "slug": "stream-app",
     "privacy": "unlisted",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -21,7 +21,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.resonate.stream-app",
-      "buildNumber": "1.0.6"
+      "buildNumber": "1.0.7"
     },
     "android": {
       "adaptiveIcon": {
@@ -29,7 +29,7 @@
         "backgroundColor": "#FFFFFF"
       },
       "package": "com.resonate.streamapp",
-      "versionCode": 4
+      "versionCode": 7
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/client/components/CookiePolicy.tsx
+++ b/client/components/CookiePolicy.tsx
@@ -2,7 +2,6 @@ import Constants from 'expo-constants';
 import React from 'react';
 import {
   Image,
-  Linking,
   Platform,
   ScrollView,
   StyleSheet,
@@ -16,35 +15,25 @@ export default function CookiePolicy() {
         style={styles.image}
         source={require('../../assets/icon.png')}
       />
+      <Text
+        style={styles.text}>
+        {"\n"}
+        {"\n"}
+        Resonate only uses cookies to guarantee core functionalities, such as keeping you logged in for a while, or remembering your theme settings. No other type of activity is tracked.
+        {"\n"}
+      </Text>
       {Platform.OS === 'ios' && (
         <>
           <Text
             style={styles.text}>
-            If you are not prompted requesting permissions, go to
+            These settings can be found at
           </Text>
           <Text
             style={{ ...styles.boldText, ...styles.text }}>
             Settings &gt; Privacy &gt; Tracking
           </Text>
-          <Text
-            style={styles.text}>
-            and enable permissions for Resonate.
-          </Text>
         </>
       )}
-      <Text
-        style={styles.text}>
-        {"\n"}
-        To ensure you get the best experience, Resonate uses cookies.
-        Functional cookies are used to keep you logged in for a while and remember your theme settings.
-        Disallowing tracking permissions precludes the use of this app.
-        {"\n"}
-      </Text>
-      <Text
-        style={styles.link}
-        onPress={() => Linking.openURL('https://resonate.is/cookie-policy')}>
-        Resonate's Cookie Policy
-      </Text>
     </ScrollView>
   )
 }

--- a/client/components/CustomStatusBar.tsx
+++ b/client/components/CustomStatusBar.tsx
@@ -5,14 +5,14 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-type Props = {
-    trackingPermissions: boolean;
+interface ICustomStatusBar {
+    isRequestingPermissions: boolean;
 }
 
-export default function CustomStatusBar({ trackingPermissions }: Props) {
+export default function CustomStatusBar({ isRequestingPermissions }: ICustomStatusBar) {
     const insets = useSafeAreaInsets();
     const colorScheme = useColorScheme();
-    const isDark: boolean = colorScheme === 'dark' && trackingPermissions;
+    const isDark: boolean = colorScheme === 'dark' && !isRequestingPermissions;
     const backgroundColor = isDark ? '#181A1B' : '#fff';
     const barStyle = isDark ? 'light-content' : 'dark-content';
 

--- a/client/helpers/Permissions.ts
+++ b/client/helpers/Permissions.ts
@@ -1,0 +1,22 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const cookiePreferences = (trackingPermissions: boolean) => `const button = document.querySelector('button[value="${trackingPermissions ? 'allow' : 'deny'}"]'); if (button !== null) {button.click();}; true;`;
+
+export const getPermissionsGranted = async () => {
+    try {
+        const value = await AsyncStorage.getItem('are_permissions_granted')
+        if (value !== null) {
+            return value === 'true';
+        }
+    } catch (e) {
+        console.log(e);
+    }
+};
+
+export const storePermissionsGranted = async (value: boolean) => {
+    try {
+        await AsyncStorage.setItem('are_permissions_granted', `${value}`);
+    } catch (e) {
+        console.log(e);
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-app",
-  "version": "1.0.0",
+  "version": "1.0.7",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
@@ -10,6 +10,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "~1.15.0",
     "expo": "~44.0.0",
     "expo-system-ui": "~1.1.0",
     "expo-tracking-transparency": "~2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,6 +1249,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@react-native-async-storage/async-storage@~1.15.0":
+  version "1.15.17"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.15.17.tgz#0dae263a52e476ffce871086f1fef5b8e44708eb"
+  integrity sha512-NQCFs47aFEch9kya/bqwdpvSdZaVRtzU7YB02L8VrmLSLpKgQH/1VwzFUBPcc1/JI1s3GU4yOLVrEbwxq+Fqcw==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cli-debugger-ui@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-5.0.1.tgz#6b1f3367b8e5211e899983065ea2e72c1901d75f"
@@ -3133,6 +3140,11 @@ is-plain-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -3569,6 +3581,13 @@ md5-file@^3.2.3:
   integrity sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==
   dependencies:
     buffer-alloc "^1.1.0"
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
I believe I *may* have worked out a solution to the Tracking settings situation. I was able to put together a small component that allows a user's Tracking preferences to be honored by the [stream repository](https://github.com/resonatecoop/stream). We unfortunately won't know whether or not it satisfies Apple's criteria for sure until they approve the new build for use in their App Store. I will keep this thread up to date when I hear back.

Also, here are some other exciting updates and additions that I was able to implement as I was digging into the above issue that are helping things feel more "app-like":
* Forward and back gestures are now functional for navigation and behaving as expected. This makes it easier, for example, if a user navigates to the forum by clicking `Join in on the discussion` after clicking a tag, they can get back to the player easily. It also seems to make navigation less clunky in general because before your only option was pressing the Resonate logo in the top left to go back to the home page to get out of whatever artist/playlist/tag etc you were on.
* Pulling down on a page, if you're at the top, reloads it.