### PR TITLE
Request permissions on press

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "stream-app",
     "slug": "stream-app",
     "privacy": "unlisted",
-    "version": "1.0.7",
+    "version": "1.0.9",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -21,7 +21,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.resonate.stream-app",
-      "buildNumber": "1.0.7"
+      "buildNumber": "1.0.9"
     },
     "android": {
       "adaptiveIcon": {
@@ -29,7 +29,7 @@
         "backgroundColor": "#FFFFFF"
       },
       "package": "com.resonate.streamapp",
-      "versionCode": 7
+      "versionCode": 9
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/client/components/CookiePolicy.tsx
+++ b/client/components/CookiePolicy.tsx
@@ -3,12 +3,17 @@ import React from 'react';
 import {
   Image,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
 } from 'react-native';
 
-export default function CookiePolicy() {
+type Props = {
+  setPromptForPermissions: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function CookiePolicy({ setPromptForPermissions }: Props) {
   return (
     <ScrollView style={styles.container}>
       <Image
@@ -19,6 +24,9 @@ export default function CookiePolicy() {
         style={styles.text}>
         {"\n"}
         {"\n"}
+        {"\n"}
+        {"\n"}
+        {"\n"}
         Resonate only uses cookies to guarantee core functionalities, such as keeping you logged in for a while, or remembering your theme settings. No other type of activity is tracked.
         {"\n"}
       </Text>
@@ -26,14 +34,22 @@ export default function CookiePolicy() {
         <>
           <Text
             style={styles.text}>
-            These settings can be found at
+            These settings are located at:
           </Text>
           <Text
-            style={{ ...styles.boldText, ...styles.text }}>
+            style={[styles.boldText, styles.text]}>
             Settings &gt; Privacy &gt; Tracking
           </Text>
         </>
       )}
+      <Pressable
+        style={styles.button}
+        onPress={() => setPromptForPermissions(true)}>
+        <Text
+          style={[styles.boldText, styles.text]}>
+          Continue
+        </Text>
+      </Pressable>
     </ScrollView>
   )
 }
@@ -41,6 +57,21 @@ export default function CookiePolicy() {
 const styles = StyleSheet.create({
   boldText: {
     fontWeight: 'bold',
+  },
+  button: {
+    margin: 20,
+    backgroundColor: 'white',
+    borderRadius: 15,
+    padding: 20,
+    alignItems: 'center',
+    shadowColor: '#181A1B',
+    shadowOffset: {
+        width: 0,
+        height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
   },
   container: {
     flex: 1,
@@ -57,6 +88,6 @@ const styles = StyleSheet.create({
     width: '80%',
   },
   text: {
-    fontSize: 20,
+    fontSize: 18,
   },
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-app",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
These changes allow the user to read our Cookie Policy, press Continue, and then be prompted for permissions. The Cookie Policy text also shows below the prompt, so, in the (likely) event that the user doesn't read the policy before pressing Continue, they can still read what we're trying to get across before choosing to accept or deny permissions.

![Simulator Screen Shot - iPhone 13 - 2022-02-27 at 11 46 02](https://user-images.githubusercontent.com/60944077/155893869-b05f0a4e-d628-4948-983c-babff5ab517f.png)

These changes also disable pull down refresh, as this would cause playback to be interrupted.

This closes #15.