### PR TITLE
Add GitHub link to Cookie Policy screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -63,7 +63,10 @@ export default function App() {
       <CustomStatusBar isRequestingPermissions={isRequestingPermissions} />
       {
         isRequestingPermissions
-          ? <CookiePolicy setPromptForPermissions={setPromptForPermissions}/>
+          ? <CookiePolicy
+            promptForPermissions={promptForPermissions}
+            setPromptForPermissions={setPromptForPermissions}
+          />
           : <WebView
             allowsBackForwardNavigationGestures
             cacheEnabled={didPermissionsChange}

--- a/client/components/CookiePolicy.tsx
+++ b/client/components/CookiePolicy.tsx
@@ -1,4 +1,5 @@
 import Constants from 'expo-constants';
+import * as Linking from 'expo-linking';
 import React from 'react';
 import {
   Image,
@@ -7,13 +8,15 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  View,
 } from 'react-native';
 
 type Props = {
+  promptForPermissions: boolean;
   setPromptForPermissions: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function CookiePolicy({ setPromptForPermissions }: Props) {
+export default function CookiePolicy({ promptForPermissions, setPromptForPermissions }: Props) {
   return (
     <ScrollView style={styles.container}>
       <Image
@@ -22,11 +25,7 @@ export default function CookiePolicy({ setPromptForPermissions }: Props) {
       />
       <Text
         style={styles.text}>
-        {"\n"}
-        {"\n"}
-        {"\n"}
-        {"\n"}
-        {"\n"}
+        {promptForPermissions && "\n \n \n \n \n \n \n \n"}
         Resonate only uses cookies to guarantee core functionalities, such as keeping you logged in for a while, or remembering your theme settings. No other type of activity is tracked.
         {"\n"}
       </Text>
@@ -42,14 +41,25 @@ export default function CookiePolicy({ setPromptForPermissions }: Props) {
           </Text>
         </>
       )}
-      <Pressable
-        style={styles.button}
-        onPress={() => setPromptForPermissions(true)}>
-        <Text
-          style={[styles.boldText, styles.text]}>
-          Continue
-        </Text>
-      </Pressable>
+      {!promptForPermissions &&
+        <>
+          <Text
+            style={{ ...styles.linkText, ...styles.text }}
+            onPress={() => Linking.openURL('https://github.com/resonatecoop')}>
+          {"\n"}
+            View Resonate's Open Source Code on GitHub.com (External Link)
+          {"\n"}
+          </Text>
+          <Pressable
+            style={styles.button}
+            onPress={() => setPromptForPermissions(true)}>
+            <Text
+              style={[styles.boldText, styles.text]}>
+              Continue
+            </Text>
+          </Pressable>
+        </>
+      }
     </ScrollView>
   )
 }
@@ -78,13 +88,14 @@ const styles = StyleSheet.create({
     marginTop: Constants.statusBarHeight,
     marginHorizontal: '10%',
   },
-  link: {
-    fontSize: 24,
+  linkText: {
     textDecorationLine: 'underline',
   },
   image: {
     height: 360,
     marginHorizontal: '10%',
+    marginTop: -80,
+    marginBottom: -10,
     width: '80%',
   },
   text: {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "~1.15.0",
     "expo": "~44.0.0",
+    "expo-linking": "~3.0.0",
     "expo-system-ui": "~1.1.0",
     "expo-tracking-transparency": "~2.1.0",
     "expo-updates": "~0.11.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2477,6 +2477,16 @@ expo-keep-awake@~10.0.1:
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-10.0.1.tgz#9f1176216c41eee20843c8232acfdca2bc32d334"
   integrity sha512-kcBtoDGkm3RRe6BpKDvR7gof/ErajEia38u92pRvNRctdh+p8AFO7GQuiipyg3iMfhcCFVTCIV7h3tuA0g/yDw==
 
+expo-linking@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/expo-linking/-/expo-linking-3.0.0.tgz#67f06b0be4ac1da911c46535a704d24eca34e344"
+  integrity sha512-TgRB4JTdhMRo79rTu9E9zwzWyBUJxHpSbHFlv0ZfMAwU+qFCsL9zZsL44R/yj7xrvcLOjqbCVmBszLQ0pFOt1g==
+  dependencies:
+    expo-constants "~13.0.0"
+    invariant "^2.2.4"
+    qs "^6.9.1"
+    url-parse "^1.4.4"
+
 expo-manifests@~0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/expo-manifests/-/expo-manifests-0.2.4.tgz#28aa7a0b21d8b932e1a49c836cfc31b5a9cd1f9c"
@@ -4092,6 +4102,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-inspect@^1.9.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
+  integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -4374,6 +4389,13 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+qs@^6.9.1:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
 
 query-string@^5.0.1:
   version "5.1.1"
@@ -4871,6 +4893,15 @@ shelljs@^0.8.4:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.6"


### PR DESCRIPTION
These changes add a link to https://github.com/resonatecoop, so users can view our open source code in an external link in their browser.

While permissions are being asked for, we move Cookie Policy text below prompt so it is still readable for the user, hiding the button they just pressed to initiate the prompt, and hiding the GitHub link, which is unpressable while the tracking prompt is active.
![Simulator Screen Shot - iPhone 8 - 2022-02-27 at 15 21 19](https://user-images.githubusercontent.com/60944077/155900596-af49d35d-37e5-496a-b7bc-033189c4a80c.png)
![Simulator Screen Shot - iPhone 8 - 2022-02-27 at 15 21 31](https://user-images.githubusercontent.com/60944077/155900598-dbd543cd-b7dc-4741-835b-0832569fc982.png)
![Simulator Screen Shot - iPhone 8 - 2022-02-27 at 15 23 22](https://user-images.githubusercontent.com/60944077/155900599-a0baf720-de74-4fb5-900a-a585e3b103b7.png)

This closes #15.