### PR TITLE
fix: add forum link.coop to allowlist

### DIFF
--- a/client/services/originAllowList.ts
+++ b/client/services/originAllowList.ts
@@ -2,6 +2,7 @@ import { Platform } from 'react-native';
 
 export const originAllowList: string[] = [
     'https://community.resonate.is',
+    'https://community.resonate.coop',
     'https://js.stripe.com',
     'https://m.stripe.network',
     'https://offen.resonate.is',


### PR DESCRIPTION
Since https://community.resonate.is/ became https://community.resonate.coop/ today, we're adding that to the allowlist.